### PR TITLE
Convert `order` parameter to string to support integer values when using Hiera/YAML

### DIFF
--- a/lib/puppet/type/file_fragment.rb
+++ b/lib/puppet/type/file_fragment.rb
@@ -30,7 +30,7 @@ Puppet::Type.newtype(:file_fragment) do
     desc "Order"
     defaultto '10'
     validate do |val|
-      fail Puppet::ParseError, "only integers > 0 are allowed and not '#{val}'" if val !~ /^\d+$/
+      fail Puppet::ParseError, "only integers > 0 are allowed and not '#{val}'" if val.to_s !~ /^\d+$/
     end
   end
 


### PR DESCRIPTION
**What's the problem?**

When using Hiera/YAML to set the `order` then extra care must be taken by the user that the parameter to order (in Hiera) is an integer-like string but not an integer already.

**How to reproduce**

Use any Hiera config of your choice in a way that sets the `order` parameter as follows.

``` yaml
# Does work.
order: '10'

# Does not work, and this is counter-intuitive.
order: 10
```

The current code fails because of the following Ruby behavior.

``` ruby
# Current (wrong) behavior.  Note that 'true' means 5 is not a number-like string.
# Which is true because 5 is not a *string* but already an integer.
1.9.3p362 :015 > 5 !~ /^\d*$/
 => true

# This is the behavior we want.  For this however we must ensure that
#5 is converted to '5' before regex matching.
1.9.3p362 :014 > '5' !~ /^\d*$/
 => false
```

**How to fix**

See pull request.  We simply make sure that whatever value is set for `order` will be converted to a string before regex matching.
