### PR TITLE
(MAINT) Remove unnecessary require

### DIFF
--- a/lib/puppet/type/file_concat.rb
+++ b/lib/puppet/type/file_concat.rb
@@ -1,4 +1,3 @@
-require 'puppet/type/file'
 require 'puppet/type/file/owner'
 require 'puppet/type/file/group'
 require 'puppet/type/file/mode'


### PR DESCRIPTION
Due to some issues in the way that Puppet loads code, and some
differences in how that works in JRuby vs MRI Ruby, doing a
`require` on the `puppet/type/file` code multiple times in a
single JRuby interpreter will cause problems.  Since this code
automatically gets loaded by Puppet before any custom
type/provider is loaded, the `require` statement is unnecessary.

This is related to the following Puppet Jira tickets:

https://tickets.puppetlabs.com/browse/SERVER-64
https://tickets.puppetlabs.com/browse/SERVER-40

and also to the following puppet-logstash PR:

https://github.com/elasticsearch/puppet-logstash/pull/196

Hopefully there will be a more permanent fix in JRuby at some point:

https://github.com/jruby/jruby/issues/2477

But in the meantime, this simple workaround makes `file_concat`
compatible with Puppet Server.