### PR TITLE
Fix unnecessary notifications

### DIFF
--- a/lib/puppet/type/file_concat.rb
+++ b/lib/puppet/type/file_concat.rb
@@ -80,7 +80,7 @@ Puppet::Type.newtype(:file_concat) do
 
     def insync?(is)
       result = super
-      string_file_diff(@resource[:path], @resource.should_content) if result
+      string_file_diff(@resource[:path], @resource.should_content) unless result
       result
     end
 


### PR DESCRIPTION
string_file_diff() should really only be called when there actually *are* differences.

Bug was introduced by refactoring in https://github.com/electrical/puppet-lib-file_concat/commit/143eed41e57c78aa18360a21d108c97512f31979