### PR TITLE
Adds major fixes that went into puppetlabs-concat

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@ example:
     File_fragment <<| tag == 'unique_tag' |>>
 
     file_concat { '/tmp/file':
-      tag     => 'unique_tag', # Mandatory
-      path    => '/tmp/file',  # Optional. If given it overrides the resource name.
-      owner   => 'root',       # Optional. Defaults to undef.
-      group   => 'root',       # Optional. Defaults to undef.
-      mode    => '0644'        # Optional. Defaults to undef.
-      order   => 'numeric'     # Optional. Set to 'numeric' or 'alpha'. Defaults to numeric.
-      replace => true          # Optional. Boolean Value. Defaults to true.
-      backup  => false         # Optional. true, false, 'puppet', or a string. Defaults to 'puppet' for Filebucketing.
+      tag            => 'unique_tag', # Mandatory
+      path           => '/tmp/file',  # Optional. If given it overrides the resource name.
+      owner          => 'root',       # Optional. Defaults to undef.
+      group          => 'root',       # Optional. Defaults to undef.
+      mode           => '0644',       # Optional. Defaults to undef.
+      order          => 'numeric',    # Optional. Set to 'numeric' or 'alpha'. Defaults to numeric.
+      replace        => true,         # Optional. Boolean Value. Defaults to true.
+      backup         => false,        # Optional. true, false, 'puppet', or a string. Defaults to 'puppet' for Filebucketing.
+      ensure_newline => false,        # Optional. Boolean Value. Defaults to false.
     }
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -50,5 +50,28 @@ example:
 
 ## Limitations
 
+A bug where module will be unable to build correct dependency graph if the manifest contains a resource to recursively purge a parent directory.
+
+Example: [MODULES-2054](https://tickets.puppetlabs.com/browse/MODULES-2054)
+~~~
+file { '/tmp/bug':
+  ensure  => directory,
+  purge   => true,
+  recurse => true,
+  force   => true
+}
+ 
+file_concat { 'test' :
+  path    => '/tmp/bug/tester',
+  tag     => 'mytag',
+  require => File['/tmp/bug']
+}
+ 
+file_fragment { 'test-1':
+  tag     => 'mytag',
+  content => 'test'
+}
+~~~
+
 ## Development
 

--- a/lib/puppet/type/file_concat.rb
+++ b/lib/puppet/type/file_concat.rb
@@ -149,10 +149,11 @@ Puppet::Type.newtype(:file_concat) do
   end
 
   def eval_generate
-    file_opts = {
-      :ensure => self[:ensure] == :absent ? :absent : :file,
-      :content => self.should_content,
-    }
+    content = self.should_content
+
+    file_opts = {}
+    file_opts[:ensure] = self[:ensure] == :absent ? :absent : :file
+    file_opts[:content] = content if !content.nil? and !content.empty?
 
     [:path, :owner, :group, :mode, :replace, :backup].each do |param|
       unless self[param].nil?

--- a/lib/puppet/type/file_concat.rb
+++ b/lib/puppet/type/file_concat.rb
@@ -81,6 +81,10 @@ Puppet::Type.newtype(:file_concat) do
     defaultto false
   end
 
+  autorequire(:file) do
+    [self[:path]]
+  end
+
   autorequire(:file_fragment) do
     catalog.resources.collect do |r|
       if r.is_a?(Puppet::Type.type(:file_fragment)) && r[:tag] == self[:tag]

--- a/lib/puppet/type/file_concat.rb
+++ b/lib/puppet/type/file_concat.rb
@@ -11,12 +11,13 @@ Puppet::Type.newtype(:file_concat) do
       File_fragment <<| tag == 'unique_tag' |>>
 
       file_concat { '/tmp/file:
-        tag   => 'unique_tag', # Mandatory
-        path  => '/tmp/file',  # Optional. If given it overrides the resource name
-        owner => 'root',       # Optional. Default to undef
-        group => 'root',       # Optional. Default to undef
-        mode  => '0644'        # Optional. Default to undef
-        order => 'numeric'     # Optional, Default to 'numeric'
+        tag            => 'unique_tag', # Mandatory
+        path           => '/tmp/file',  # Optional. If given it overrides the resource name
+        owner          => 'root',       # Optional. Default to undef
+        group          => 'root',       # Optional. Default to undef
+        mode           => '0644',       # Optional. Default to undef
+        order          => 'numeric',    # Optional, Default to 'numeric'
+        ensure_newline => false,        # Optional, Defaults to false
       }
   "
   ensurable do
@@ -73,6 +74,11 @@ Puppet::Type.newtype(:file_concat) do
 
   newparam(:validate_cmd) do
     desc "Validates file."
+  end
+
+  newparam(:ensure_newline) do
+    desc "Whether to ensure there is a newline after each fragment."
+    defaultto false
   end
 
   autorequire(:file_fragment) do
@@ -134,6 +140,11 @@ Puppet::Type.newtype(:file_concat) do
       tmp = Puppet::FileServing::Content.indirection.find(@source, :environment => catalog.environment)
       fragment_content = tmp.content unless tmp.nil?
     end
+
+    if self[:ensure_newline]
+      fragment_content << "\n" unless fragment_content =~ /\n$/
+    end
+
     fragment_content
   end
 

--- a/metadata.json
+++ b/metadata.json
@@ -69,6 +69,21 @@
         "10",
         "11"
       ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "Server 2003 R2",
+        "Server 2008 R2",
+        "Server 2012",
+        "Server 2012 R2"
+      ]
+    },
+    {
+      "operatingsystem": "OSX",
+      "operatingsystemrelease": [
+        "10.9"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
This is mostly a sync up of the code base from puppetlabs-concat.

This PR will include features:
- ensure_newline functionality

Fixes:
- fixes how the empty concats are handled (defaulted 'force' behavior)
- fixes file autorequire to add parent dependencies to the graph
- updates metadata to include windows and osx.

Limitations:
- Unfortunately the bug described in MODULES-2054 cannot be implemented without running into PUP-1963 and I deemed it more important to maintain working notify/subscribe functionality.