### PR TITLE
Fix "Could not find a directory environment"

### DIFF
--- a/lib/puppet/type/file_concat.rb
+++ b/lib/puppet/type/file_concat.rb
@@ -141,7 +141,7 @@ Puppet::Type.newtype(:file_concat) do
         end
       end
       self.fail "Could not retrieve source(s) #{Array(r[:source]).join(", ")}" unless @source
-      tmp = Puppet::FileServing::Content.indirection.find(@source, :environment => catalog.environment)
+      tmp = Puppet::FileServing::Content.indirection.find(@source)
       fragment_content = tmp.content unless tmp.nil?
     end
 


### PR DESCRIPTION
Get error (master branch)
```
Error: /Stage[main]/Logstash::Config/File_concat[ls-config]: Failed to generate additional resources using 'eval_generate': Could not find a directory environment named 'logstash_refactor' anywhere in the path: /etc/puppetlabs/code/environments. Does the directory exist?
```

Looks like it's related to https://github.com/electrical/puppet-lib-file_concat/issues/28

Removing of 2 argument in Puppet::FileServing::Content.indirection.find helps me.

Also change `environment => catalog.environment` to `catalog.environment_instance` helps
environment_instance # The actual environment instance that was used during compilation
https://github.com/puppetlabs/puppet/blob/master/lib/puppet/resource/catalog.rb#L55-L56

Honestly I'am a newcommer in Puppet, so may be I do smth wrong :)
Anyway we need fix this issue